### PR TITLE
Handle absence of curl/wget with error message

### DIFF
--- a/modulejail
+++ b/modulejail
@@ -482,8 +482,8 @@ check_for_updates() {
         # are not needed.
         body=$(wget -q -T 10 -O - "$update_url" 2>/dev/null) || return 0
     else
-        printf 'modulejail: error: no curl/wget, set MODULEJAIL_NO_UPDATE_CHECK=1 to avoid\n' >&2
-        return $EX_UNAVAILABLE
+        printf 'modulejail: error: no curl/wget in PATH\n' >&2
+        return 0
     fi
 
     # Extract the first "name": "..." value from the JSON array.

--- a/modulejail
+++ b/modulejail
@@ -21,6 +21,7 @@ EX_OK=0
 #   64=usage 66=noinput 70=software 71=oserr 73=cantcreat 77=noperm
 EX_USAGE=64
 EX_NOINPUT=66
+EX_UNAVAILABLE=69
 EX_SOFTWARE=70
 EX_OSERR=71
 EX_CANTCREAT=73
@@ -481,7 +482,8 @@ check_for_updates() {
         # are not needed.
         body=$(wget -q -T 10 -O - "$update_url" 2>/dev/null) || return 0
     else
-        return 0
+        printf 'modulejail: error: no curl/wget, set MODULEJAIL_NO_UPDATE_CHECK=1 to avoid\n' >&2
+        return $EX_UNAVAILABLE
     fi
 
     # Extract the first "name": "..." value from the JSON array.

--- a/modulejail
+++ b/modulejail
@@ -21,7 +21,6 @@ EX_OK=0
 #   64=usage 66=noinput 70=software 71=oserr 73=cantcreat 77=noperm
 EX_USAGE=64
 EX_NOINPUT=66
-EX_UNAVAILABLE=69
 EX_SOFTWARE=70
 EX_OSERR=71
 EX_CANTCREAT=73
@@ -482,7 +481,7 @@ check_for_updates() {
         # are not needed.
         body=$(wget -q -T 10 -O - "$update_url" 2>/dev/null) || return 0
     else
-        printf 'modulejail: error: no curl/wget in PATH\n' >&2
+        printf 'modulejail: notice: no curl/wget in PATH, cannot check for update\n' >&2
         return 0
     fi
 


### PR DESCRIPTION
Add error handling for missing curl/wget in modulejail (can be avoided by setting MODULEJAIL_NO_UPDATE_CHECK=1)