### PR TITLE
Register the invocation used to produce the blacklist file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to ModuleJail are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-05-20
+
+### Added
+
+- An invocation header — can be copied and pasted for reproducible results.
+
 ## [1.2.3] - 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ when `/usr/bin/logger` is available, so blocked attempts produce a syslog
 trail) or `/bin/true` (under `--no-syslog-logging`, silent fallback, or when
 logger is absent). See the *Viewing blocked module attempts* section below.
 
+The invocation used to create the blacklist file is noted in the header line
+that starts with `invocation:`, and can be copied & pasted for reproducible
+results.
+
 The tool is aimed at Linux fleet operators who need to harden many servers
 against the wave of AI-assisted kernel privilege-escalation discoveries. Every
 additional loaded module is additional latent attack surface for the next

--- a/man/modulejail.8.in
+++ b/man/modulejail.8.in
@@ -289,6 +289,13 @@ visible cue. Use
 .B \-\-no\-syslog\-logging
 explicitly when the v1.1.4 install-line body is a hard requirement.
 
+.SH INVOCATION
+A header line starting with
+.B # invocation:
+is added to the blacklist, which registers the invocation that was used
+to produce the blacklist, and can be copied and pasted into the terminal
+for reproducible results.
+
 .SH SCOPE OF THE BLACKLIST
 A
 .BR modprobe.d (5)

--- a/modulejail
+++ b/modulejail
@@ -147,8 +147,26 @@ usage() {
     printf '                               Test-only plumbing; end-user operators leave unset.\n'
 }
 
+quote_arg() {
+    case "$1" in
+        ""|*[!a-zA-Z0-9._/=-]*)
+            printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
+            ;;
+        *)
+            printf '%s' "$1"
+            ;;
+    esac
+}
+
+# --- Reproducible invocation string ---
+# When the script is piped into sh (like: `curl ... | sh`) $0 is 'sh' and $@ empty.
+# In other cases (even `sh -c '...'`) $invocation is script + arguments, properly quoted.
+invocation=$(quote_arg "$0")
+for arg in "$@"; do
+    invocation="$invocation $(quote_arg "$arg")"
+done
+
 # --- Argument parser (manual case loop — POSIX, supports long options) ---
-invocation="$0 $@"
 while [ $# -gt 0 ]; do
     case "$1" in
         -p|--profile)

--- a/modulejail
+++ b/modulejail
@@ -148,6 +148,7 @@ usage() {
 }
 
 # --- Argument parser (manual case loop — POSIX, supports long options) ---
+invocation="$0 $@"
 while [ $# -gt 0 ]; do
     case "$1" in
         -p|--profile)
@@ -688,13 +689,13 @@ tmp=$(mktemp "${target_dir}/.modulejail-blacklist.conf.XXXXXX") || {
     exit $EX_CANTCREAT
 }
 
-# Write 7-line header + one install line per blacklisted module. The install
+# Write 8-line header + one install line per blacklisted module. The install
 # line takes one of two forms depending on the generation-time logger
 # detection (see USE_LOGGER above); emit_install_line picks the right form
 # and the header documents which one was chosen.
 # Header contains tool version + repo URL + profile + kernel + sha256 fingerprint +
-# install-line annotation + edit-by-hand disclaimer. NO wall-clock; header is
-# a deterministic function of inputs. Fingerprint is computed above the
+# install-line annotation + invocation + edit-by-hand disclaimer. NO wall-clock;
+# header is a deterministic function of inputs. Fingerprint is computed above the
 # render block.
 {
     printf '# modulejail %s\n' "$VERSION"
@@ -715,6 +716,7 @@ tmp=$(mktemp "${target_dir}/.modulejail-blacklist.conf.XXXXXX") || {
             printf '# install-line: /bin/false (silent, --fail-on-module-load)\n'
         fi
     fi
+    printf '# invocation: %s\n' "$invocation"
     printf '# Do not edit by hand — regenerate with modulejail(8).\n'
     emit_install_line "$blacklist"
 } > "$tmp"

--- a/modulejail
+++ b/modulejail
@@ -150,7 +150,7 @@ usage() {
 quote_arg() {
     case "$1" in
         ""|*[!a-zA-Z0-9._/=-]*)
-            printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
+            printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
             ;;
         *)
             printf '%s' "$1"

--- a/tests/cases/header-invocation.sh
+++ b/tests/cases/header-invocation.sh
@@ -47,7 +47,8 @@ OUT="$CASE_TMP/out'put.conf"
     case_fail "modulejail exited $? (expected 0); stderr=$(cat "$CASE_TMP/stderr")"
 
 # Header invocation test args with single quotes
-assert_grep "^# invocation: $MODULEJAIL_BIN -o '$CASE_TMP/out'''put.conf'$" \
+head "$OUT"
+assert_grep "^# invocation: $MODULEJAIL_BIN -o '$CASE_TMP/out'\\\\''put.conf'$" \
     "$OUT" header-invocation-args-with-single-quotes
 
 case_pass

--- a/tests/cases/header-invocation.sh
+++ b/tests/cases/header-invocation.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Case: with /usr/bin/logger present on the host AND no --no-syslog-logging
+# flag, modulejail emits the syslog-logging install-line form and the
+# matching header annotation.
+#
+# Skip (not fail) when /usr/bin/logger is absent on the running host: this
+# case asserts the positive default-on path, which is only exercisable when
+# logger is actually executable. The complementary logger-absent-fallback.sh
+# case covers the negative path via MODULEJAIL_LOGGER_PATH override.
+set -eu
+
+CASE_NAME=header-invocation
+export CASE_NAME
+
+# shellcheck source=tests/lib/case-env.sh disable=SC1091
+. "$(dirname "$0")/../lib/case-env.sh"
+# shellcheck source=tests/lib/assert.sh disable=SC1091
+. "$REPO_ROOT/tests/lib/assert.sh"
+
+trap 'rm -rf "$CASE_TMP"' EXIT INT HUP TERM
+
+OUT=$CASE_TMP/out.conf
+"$MODULEJAIL_BIN" -o "$OUT" > "$CASE_TMP/stdout" 2> "$CASE_TMP/stderr" || \
+    case_fail "modulejail exited $? (expected 0); stderr=$(cat "$CASE_TMP/stderr")"
+
+# Header invocation test plain args
+assert_grep "^# invocation: $MODULEJAIL_BIN -o $OUT$" \
+    "$OUT" header-invocation-plain-args
+
+"$MODULEJAIL_BIN" --whitelist-file '' -o "$OUT" > "$CASE_TMP/stdout" 2> "$CASE_TMP/stderr" || \
+    case_fail "modulejail exited $? (expected 0); stderr=$(cat "$CASE_TMP/stderr")"
+
+# Header invocation test empty args
+assert_grep "^# invocation: $MODULEJAIL_BIN --whitelist-file '' -o $OUT$" \
+    "$OUT" header-invocation-empty-args
+
+OUT="$CASE_TMP/out put.conf"
+"$MODULEJAIL_BIN" -o "$OUT" > "$CASE_TMP/stdout" 2> "$CASE_TMP/stderr" || \
+    case_fail "modulejail exited $? (expected 0); stderr=$(cat "$CASE_TMP/stderr")"
+
+# Header invocation test args with spaces
+assert_grep "^# invocation: $MODULEJAIL_BIN -o '$OUT'$" \
+    "$OUT" header-invocation-args-with-spaces
+
+OUT="$CASE_TMP/out'put.conf"
+"$MODULEJAIL_BIN" -o "$OUT" > "$CASE_TMP/stdout" 2> "$CASE_TMP/stderr" || \
+    case_fail "modulejail exited $? (expected 0); stderr=$(cat "$CASE_TMP/stderr")"
+
+# Header invocation test args with single quotes
+assert_grep "^# invocation: $MODULEJAIL_BIN -o '$CASE_TMP/out'''put.conf'$" \
+    "$OUT" header-invocation-args-with-single-quotes
+
+case_pass

--- a/tests/cases/v1.1.4-regression.sh
+++ b/tests/cases/v1.1.4-regression.sh
@@ -104,7 +104,7 @@ MODULEJAIL_DEFAULT_WHITELIST_FILE=$CASE_TMP/default-whitelist-absent.conf \
 # match the archived v1.1.4 reference.
 EXPECTED_FILTERED=$CASE_TMP/expected.body
 ACTUAL_FILTERED=$CASE_TMP/actual.body
-grep -v -E '^# modulejail |^# fingerprint:|^# install-line:' \
+grep -v -E '^# modulejail |^# fingerprint:|^# install-line:|^# invocation:' \
     "$FIXTURE_DIR/expected-blacklist.conf" > "$EXPECTED_FILTERED"
 grep -v -E '^# modulejail |^# fingerprint:|^# install-line:' \
     "$ACTUAL" > "$ACTUAL_FILTERED"

--- a/tests/cases/v1.1.4-regression.sh
+++ b/tests/cases/v1.1.4-regression.sh
@@ -106,7 +106,7 @@ EXPECTED_FILTERED=$CASE_TMP/expected.body
 ACTUAL_FILTERED=$CASE_TMP/actual.body
 grep -v -E '^# modulejail |^# fingerprint:|^# install-line:|^# invocation:' \
     "$FIXTURE_DIR/expected-blacklist.conf" > "$EXPECTED_FILTERED"
-grep -v -E '^# modulejail |^# fingerprint:|^# install-line:' \
+grep -v -E '^# modulejail |^# fingerprint:|^# install-line:|^# invocation:' \
     "$ACTUAL" > "$ACTUAL_FILTERED"
 
 if ! diff -u "$EXPECTED_FILTERED" "$ACTUAL_FILTERED" > "$CASE_TMP/diff.out"; then


### PR DESCRIPTION
It is useful to register the exact invocation in the blacklist file; some options are explained, but not all.