### PR TITLE
Document force

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,41 @@ was not set, ModuleJail silently falls back to the `/bin/true` form
 (matching the v1.1.4 behaviour on minimal hosts). No stderr warning is
 emitted; the header annotation is the only visible cue.
 
+## Failing on blocked module loads (`-f` / `--fail-on-module-load`)
+
+By default, blacklisted module loads succeed silently: the generated
+install lines end with `exit 0` (when logger is present) or `/bin/true`
+(when it is not), so `modprobe <module>` returns 0 even though the module
+was not actually loaded. This is the safe default — it prevents
+breakage in scripts and services that unconditionally call `modprobe`
+and check its return code.
+
+To make blocked loads fail loudly instead, pass `-f` or
+`--fail-on-module-load`:
+
+```sh
+sudo modulejail -f
+sudo modulejail --fail-on-module-load
+```
+
+With this flag, the install-line body uses `/bin/false` instead of
+`exit 0` or `/bin/true`, so `modprobe <module>` returns a non-zero exit
+code for blacklisted modules. This is useful when you want tooling to
+detect and alert on blocked module attempts rather than silently
+swallowing them.
+
+The header annotation reflects the mode:
+
+```
+# install-line: /bin/sh + logger + /bin/false (syslog tag: modulejail, --fail-on-module-load)
+```
+
+or, without logger:
+
+```
+# install-line: /bin/false (silent, --fail-on-module-load)
+```
+
 ## Scope of the blacklist (what it blocks, what it doesn't)
 
 A `modprobe.d` blacklist blocks **automatic** module loading: udev

--- a/README.md
+++ b/README.md
@@ -530,6 +530,27 @@ section above for the full framing, and
 close the root-with-intent gap (kernel lockdown mode, module signature
 enforcement, `kernel.modules_disabled=1`).
 
+## Options reference
+
+| Option | Description |
+|--------|-------------|
+| `-p`, `--profile {minimal\|conservative\|desktop}` | Built-in baseline profile (default: `conservative`) |
+| `-o`, `--output PATH` | Output path for the generated blacklist file (default: `/etc/modprobe.d/modulejail-blacklist.conf`) |
+| `--whitelist-file PATH` | Append module names from PATH to the keep-set. One module per line; `#` starts a comment. File must not be group- or world-writable. Default: `/etc/modulejail/whitelist.conf` |
+| `--no-whitelist-file` | Skip the default whitelist file even if present. Mutually exclusive with `--whitelist-file PATH` |
+| `--no-syslog-logging` | Force `/bin/true` install lines (v1.1.4 behavior). By default, blocked module loads are logged to syslog with tag `modulejail` |
+| `-f`, `--fail-on-module-load` | Blocked module loads return a non-zero exit code (`modprobe` fails loudly). Default: blocked loads silently succeed |
+| `-V`, `--version` | Show program version and exit |
+| `-h`, `--help` | Show help text and exit |
+
+Environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `MODULEJAIL_NO_UPDATE_CHECK` | Set to any non-empty value to skip the post-run update check |
+| `MODULEJAIL_LOGGER_PATH` | Path to the logger binary for syslog install-line detection (default: `/usr/bin/logger`) |
+| `MODULEJAIL_DEFAULT_WHITELIST_FILE` | Override the auto-detected whitelist path (default: `/etc/modulejail/whitelist.conf`) |
+
 ## Exit codes
 
 Exit codes follow `sysexits.h` conventions (see `man 3 sysexits`). Fleet

--- a/man/modulejail.8.in
+++ b/man/modulejail.8.in
@@ -20,6 +20,7 @@ modulejail \- shrink a Linux host's kernel-module attack surface
 .RB [ \-\-no\-syslog\-logging ]
 .RB [ \-\-dry\-run ]
 .RB [ \-\-quiet | \-\-verbose ]
+.RB [ \-f ]
 .RB [ \-\-output\-format
 .IR format ]
 .br
@@ -247,6 +248,25 @@ field becomes
 and
 .B output_path
 is the would-be path; no file is written). Available since v1.3.
+.TP
+.BR \-f ", " \-\-fail\-on\-module\-load
+Make blocked module loads return a non-zero exit code so that
+.B modprobe
+fails loudly for blacklisted modules. By default, blocked loads
+silently succeed
+.RB ( modprobe
+returns 0 even though the module was not loaded). With this flag,
+the install-line body uses
+.B /bin/false
+instead of
+.B "exit 0"
+or
+.BR /bin/true ,
+so
+.B modprobe <module>
+returns non-zero for any blacklisted module. Use this when
+blocked loads should produce a visible error rather than silently
+succeeding.
 .TP
 .BR \-V ", " \-\-version
 Print version, repository URL, and license, then exit


### PR DESCRIPTION
Document the -f/--fail-on-module-load option in the manpage and README, and add an options reference table to the README.