### PR TITLE
feat(nix): Nix flake for NixOS-native install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - name: nix flake check
         run: nix flake check --print-build-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,11 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y mandoc
       - name: Run host-local cases
         run: sh tests/run-fixtures.sh --only-host-local
+
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+      - name: nix flake check
+        run: nix flake check --print-build-logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ parity on the NixOS path.
   attempt produces a `journalctl -t modulejail` event. The NixOS logger
   path defaults to `/run/current-system/sw/bin/logger`; override at
   generation time with `MODULEJAIL_LOGGER_PATH`.
+- **Nix flake packaging**: a root `flake.nix` exposes `packages.default`,
+  `apps.default` (`nix run github:jnuyens/modulejail`), a shellcheck +
+  build `checks.default`, and a dev shell. The tool is wrapped with its
+  runtime dependencies for minimal-host correctness. A non-required `nix`
+  CI job runs `nix flake check`.
 
 ## [1.4.3] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,30 @@ makepkg -si
 
 AUR package: <https://aur.archlinux.org/packages/modulejail>
 
+### Install on NixOS via flake
+
+modulejail ships a flake. Run it without installing:
+
+```sh
+nix run github:jnuyens/modulejail -- --help
+```
+
+Or add it to a flake-based system config:
+
+```nix
+{
+  inputs.modulejail.url = "github:jnuyens/modulejail";
+
+  # in your system's module, expose the tool:
+  # environment.systemPackages = [ inputs.modulejail.packages.${pkgs.system}.default ];
+}
+```
+
+The flake wraps the tool with its runtime dependencies (kmod, gawk,
+coreutils, util-linux), so it runs on a minimal NixOS host without relying
+on the system PATH. The generated blacklist still targets the runtime logger
+at `/run/current-system/sw/bin/logger`.
+
 On NixOS, ModuleJail generates a Nix expression instead of
 a `modprobe.d` blacklist. The output is a Nix module that can be imported
 into your `configuration.nix`:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,95 @@
+{
+  description = "modulejail: proactively shrink a Linux host's loaded-module attack surface";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      # Single source of truth: read VERSION='x.y.z' from the modulejail script,
+      # the same value packaging/build.sh reads with awk.
+      version =
+        let
+          lines = nixpkgs.lib.splitString "\n" (builtins.readFile ./modulejail);
+          verLine = builtins.head (builtins.filter (nixpkgs.lib.hasPrefix "VERSION='") lines);
+          m = builtins.match "VERSION='([^']+)'" verLine;
+        in
+        builtins.head m;
+
+      # Fixed date for the manpage .TH line. Reproducible (no wall-clock in the
+      # sandbox). Set to the intended v1.5.0 release date.
+      releaseDate = "2026-07-10";
+
+      modulejailPkg = pkgs:
+        pkgs.stdenvNoCC.mkDerivation {
+          pname = "modulejail";
+          inherit version;
+          src = ./.;
+
+          nativeBuildInputs = [ pkgs.makeWrapper pkgs.installShellFiles ];
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+
+            install -Dm755 modulejail $out/bin/modulejail
+
+            substitute man/modulejail.8.in modulejail.8 \
+              --replace-fail __VERSION__ "${version}" \
+              --replace-fail __DATE__ "${releaseDate}"
+            installManPage modulejail.8
+
+            runHook postInstall
+          '';
+
+          postFixup = ''
+            wrapProgram $out/bin/modulejail \
+              --prefix PATH : ${pkgs.lib.makeBinPath [
+                pkgs.kmod pkgs.gawk pkgs.coreutils pkgs.util-linux pkgs.gnused pkgs.gnugrep
+              ]}
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Proactively shrink a Linux host's loaded-module attack surface";
+            homepage = "https://github.com/jnuyens/modulejail";
+            license = licenses.gpl3Only;
+            platforms = platforms.linux;
+            mainProgram = "modulejail";
+          };
+        };
+    in
+    {
+      packages = forAllSystems (pkgs: rec {
+        modulejail = modulejailPkg pkgs;
+        default = modulejail;
+      });
+
+      apps = forAllSystems (pkgs: rec {
+        modulejail = {
+          type = "app";
+          program = "${modulejailPkg pkgs}/bin/modulejail";
+        };
+        default = modulejail;
+      });
+
+      checks = forAllSystems (pkgs: {
+        build = modulejailPkg pkgs;
+        shellcheck = pkgs.runCommand "modulejail-shellcheck"
+          { nativeBuildInputs = [ pkgs.shellcheck ]; }
+          ''
+            shellcheck -S warning ${./modulejail}
+            touch $out
+          '';
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [ pkgs.shellcheck pkgs.mandoc pkgs.kmod pkgs.gawk ];
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
         let
           lines = nixpkgs.lib.splitString "\n" (builtins.readFile ./modulejail);
           verLine = builtins.head (builtins.filter (nixpkgs.lib.hasPrefix "VERSION='") lines);
-          m = builtins.match "VERSION='([^']+)'" verLine;
+          m = builtins.match "VERSION='([^']+)'.*" verLine;
         in
         builtins.head m;
 


### PR DESCRIPTION
Adds a root `flake.nix` so NixOS users can `nix run github:jnuyens/modulejail` or add modulejail as a flake input, instead of `curl | sh`.

- `packages.default` / `apps.default`, plus `checks` (build + shellcheck) and a dev shell, over x86_64 and aarch64 Linux.
- Version is read from the `modulejail` script (single source of truth, same value `build.sh` uses). Manpage substituted like the .deb/.rpm path.
- Tool is wrapped with its runtime deps (kmod, gawk, coreutils, util-linux) so it runs on a minimal NixOS host; generated config still targets the runtime logger at `/run/current-system/sw/bin/logger`.
- Non-required `nix` CI job runs `nix flake check` (installer pinned to a release SHA).

Verified on a real NixOS host (26.05, kernel 6.18.35): `nix flake check` passes, `nix build` + `nix run` work, and generating a blacklist produces valid Nix (7150/7296 modules, both `boot.blacklistedKernelModules` and `boot.extraModprobeConfig`, `nix-instantiate --parse` clean).

Ships in v1.5.0. The nixpkgs upstream PR is a follow-up once v1.5.0 is tagged.
